### PR TITLE
Handle missing weather data gracefully

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -231,7 +231,8 @@ components:
                 data:
                   type: object
                   properties:
-                    challenge: { type: string, example: "NEW_PASSWORD_REQUIRED" }
+                    challenge:
+                      { type: string, example: "NEW_PASSWORD_REQUIRED" }
                     session: { type: string }
                     parameters:
                       type: object
@@ -256,10 +257,12 @@ components:
         details:
           type: object
           properties:
-            id: { type: string, example: "2eb7e841-f5a4-4c3e-845c-c82024c832fa" }
+            id:
+              { type: string, example: "2eb7e841-f5a4-4c3e-845c-c82024c832fa" }
 
     WeatherNow:
       type: object
+      nullable: true
       properties:
         temperature: { type: number, example: 28.7 }
         windspeed: { type: number, example: 13 }
@@ -271,13 +274,15 @@ components:
         id: { type: integer, example: 25 }
         name: { type: string, example: "Dantooine" }
         climate: { type: string, example: "temperate" }
-        terrain: { type: string, example: "oceans, savannas, mountains, grasslands" }
+        terrain:
+          { type: string, example: "oceans, savannas, mountains, grasslands" }
         population: { type: string, example: "1000" }
         weather: { $ref: "#/components/schemas/WeatherNow" }
         source:
           type: object
           properties:
-            planetUrl: { type: string, example: "https://swapi.info/api/planets/25" }
+            planetUrl:
+              { type: string, example: "https://swapi.info/api/planets/25" }
 
     FusionadoResult:
       type: object
@@ -306,7 +311,8 @@ components:
         source:
           type: object
           properties:
-            planetUrl: { type: string, example: "https://swapi.info/api/planets/24" }
+            planetUrl:
+              { type: string, example: "https://swapi.info/api/planets/24" }
 
     HistorialPage:
       type: object

--- a/lambdas/auth/src/config/container.ts
+++ b/lambdas/auth/src/config/container.ts
@@ -1,6 +1,6 @@
 import { IUseCase } from "core";
 import { Container } from "inversify";
-import { IAuthDAO } from "../utils//interfaces";
+import { IAuthDAO } from "../utils/interfaces";
 import { Types } from "./types";
 import { AuthDAO } from "../dao/auth";
 import { LoginUserUseCase } from "../app/login/usecase";
@@ -11,8 +11,14 @@ import { ChallengeNewPasswordUseCase } from "../app/challenge-newpassword/usecas
 const container = new Container();
 container.bind<IAuthDAO>(Types.AuthDAO).to(AuthDAO);
 container.bind<IUseCase<any, any>>(Types.LoginUseCaseApp).to(LoginUserUseCase);
-container.bind<IUseCase<any, any>>(Types.CreateUserUseCaseApp).to(CreateUserUseCase);
-container.bind<IUseCase<any, any>>(Types.ChallengeNewPasswordUseCaseApp).to(ChallengeNewPasswordUseCase);
-container.bind<IUseCase<any, any>>(Types.ChallengeMFAUseCaseApp).to(ChallengeMFAUseCase);
+container
+  .bind<IUseCase<any, any>>(Types.CreateUserUseCaseApp)
+  .to(CreateUserUseCase);
+container
+  .bind<IUseCase<any, any>>(Types.ChallengeNewPasswordUseCaseApp)
+  .to(ChallengeNewPasswordUseCase);
+container
+  .bind<IUseCase<any, any>>(Types.ChallengeMFAUseCaseApp)
+  .to(ChallengeMFAUseCase);
 
 export { container as Container };

--- a/lambdas/starwars/src/app/fusionados/usecase.spec.ts
+++ b/lambdas/starwars/src/app/fusionados/usecase.spec.ts
@@ -64,6 +64,35 @@ describe("FusionadosUseCase", () => {
     expect(putFusion).toHaveBeenCalledWith(1, expect.any(Object), 60 * 30);
   });
 
+  it("200 ok con weather null si no hay datos", async () => {
+    getFusionByPlanet.mockResolvedValueOnce(null);
+    getPlanetById.mockResolvedValueOnce({
+      name: "Tatooine",
+      climate: "arid",
+      terrain: "desert",
+      population: "200000",
+      url: "https://swapi.info/api/planets/1",
+    });
+    getCurrent.mockResolvedValueOnce(null);
+
+    const event = makeApiEvent({
+      httpMethod: "GET",
+      path: "/starwars/fusionados",
+      queryStringParameters: { planetId: "1" },
+    });
+
+    const res = await Fusionados(event as any);
+    const body = JSON.parse(res.body);
+
+    expect(res.statusCode).toBe(200);
+    expect(body).toMatchObject({
+      status: "ok",
+      cached: false,
+    });
+    expect(body.details.weather).toBeNull();
+    expect(putFusion).toHaveBeenCalledWith(1, expect.any(Object), 60 * 30);
+  });
+
   it("200 bad_request si planetId inválido", async () => {
     const event = makeApiEvent({
       httpMethod: "GET",

--- a/lambdas/starwars/src/config/container.ts
+++ b/lambdas/starwars/src/config/container.ts
@@ -1,6 +1,6 @@
 import { IUseCase } from "core";
 import { Container } from "inversify";
-import { IStorageDAO, ISwapiDAO, IWeatherDAO } from "../utils//interfaces";
+import { IStorageDAO, ISwapiDAO, IWeatherDAO } from "../utils/interfaces";
 import { Types } from "./types";
 import { WeatherDAO } from "../dao/weather";
 import { SwapiDAO } from "../dao/swapi";
@@ -13,8 +13,14 @@ const container = new Container();
 container.bind<ISwapiDAO>(Types.SwapiDAO).to(SwapiDAO);
 container.bind<IWeatherDAO>(Types.WeatherDAO).to(WeatherDAO);
 container.bind<IStorageDAO>(Types.StorageDAO).to(StorageDAO);
-container.bind<IUseCase<any, any>>(Types.FusionadosUseCaseApp).to(FusionadosUseCase);
-container.bind<IUseCase<any, any>>(Types.AlmacenadosUseCaseApp).to(AlmacenadosUseCase);
-container.bind<IUseCase<any, any>>(Types.HistorialUseCaseApp).to(HistorialUseCase);
+container
+  .bind<IUseCase<any, any>>(Types.FusionadosUseCaseApp)
+  .to(FusionadosUseCase);
+container
+  .bind<IUseCase<any, any>>(Types.AlmacenadosUseCaseApp)
+  .to(AlmacenadosUseCase);
+container
+  .bind<IUseCase<any, any>>(Types.HistorialUseCaseApp)
+  .to(HistorialUseCase);
 
 export { container as Container };

--- a/lambdas/starwars/src/dao/weather.ts
+++ b/lambdas/starwars/src/dao/weather.ts
@@ -1,18 +1,19 @@
 // lambdas/auth/src/dao/auth.ts
-import { injectable } from 'inversify';
-import { IWeatherDAO, WeatherCurrent, WeatherNow } from '../utils/interfaces';
-import { PLANET_COORDS } from '../helpers/planets';
+import { injectable } from "inversify";
+import { IWeatherDAO, WeatherCurrent, WeatherNow } from "../utils/interfaces";
+import { PLANET_COORDS } from "../helpers/planets";
 
 @injectable()
 export class WeatherDAO implements IWeatherDAO {
-  async getCurrent(name: string): Promise<WeatherNow | {}> {
+  async getCurrent(name: string): Promise<WeatherNow> {
     const p = PLANET_COORDS[name];
-    if (!p) return {}; // si no tenemos coords, omitimos clima
-    const url =
-      `https://api.open-meteo.com/v1/forecast?latitude=${p.lat}&longitude=${p.lon}&current=temperature_2m,wind_speed_10m&timezone=UTC`;
-    const r = await fetch(url, { headers: { accept: 'application/json' } });
-    if (!r.ok) return {};
-    const j = await r.json() as WeatherCurrent;
+    if (!p) return null; // si no tenemos coords, omitimos clima
+
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${p.lat}&longitude=${p.lon}&current=temperature_2m,wind_speed_10m&timezone=UTC`;
+    const r = await fetch(url, { headers: { accept: "application/json" } });
+    if (!r.ok) return null;
+
+    const j = (await r.json()) as WeatherCurrent;
     return {
       temperature: j.current?.temperature_2m ?? 0,
       windspeed: j.current?.wind_speed_10m ?? 0,

--- a/lambdas/starwars/src/utils/interfaces.ts
+++ b/lambdas/starwars/src/utils/interfaces.ts
@@ -1,16 +1,19 @@
-export interface ISwapiDAO{
+export interface ISwapiDAO {
   getPlanetById(id?: number): Promise<SwapiPlanet>;
 }
 
 export interface IWeatherDAO {
-  getCurrent(name: string): Promise<WeatherNow | {}>;
+  getCurrent(name: string): Promise<WeatherNow>;
 }
 
 export interface IStorageDAO {
   putHistory(payload: any): Promise<void>;
   putFusion(planetId: number, data: any, ttlSeconds: number): Promise<void>;
   getFusionByPlanet(planetId: number): Promise<any | null>;
-  listFusion(limit?: number, nextKey?: { pk: string; sk: number }): Promise<{ items: any[]; nextKey?: { pk: string; sk: number } }>;
+  listFusion(
+    limit?: number,
+    nextKey?: { pk: string; sk: number },
+  ): Promise<{ items: any[]; nextKey?: { pk: string; sk: number } }>;
 }
 
 export type SwapiPlanet = {
@@ -26,7 +29,11 @@ export type WeatherCurrent = {
     temperature_2m?: number;
     wind_speed_10m?: number;
     time?: string;
-  }
-}
+  };
+};
 
-export type WeatherNow = { temperature: number; windspeed: number; time: string } | null;
+export type WeatherNow = {
+  temperature: number;
+  windspeed: number;
+  time: string;
+} | null;


### PR DESCRIPTION
## Summary
- return `null` from WeatherDAO when weather data is unavailable
- allow `weather` to be `null` in the public API spec
- add regression test and clean up container imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6453694788325b51206276b31f1ae